### PR TITLE
Silvio fixes 105

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install this collection and configure a playbook to use it (there is an example 
 Launch the playbook to init git and create the initial basic content. To to that, use tags git-init, filetree_create, git-push and git-branches:
 
 ```
-ansible-playbook gitlab_setup.yml --tags git-init,filetree_create,git-push,git-branches
+$ ansible-navigator run gitlab_setup.yml  -m stdout --eei quay.io/automationiberia/aap/ee-casc --tags git-init,filetree_create,git-push,git-branches
 ```
 
 Git repository is ready to launch the first CD and set the controller configured from CasC approach. As day 0, it is needed to do it from CLI to, after that, configure the pipelines, webhooks and everthing needed to have a complete CasC for the controller.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -44,16 +44,16 @@ tags: [casc,setup,controller]
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: http://example.com/repository
+repository: https://github.com/automationiberia/casc_setup/
 
 # The URL to any online docs
-documentation: http://docs.example.com
+documentation: https://github.com/automationiberia/casc_setup/
 
 # The URL to the homepage of the collection/project
-homepage: http://example.com
+homepage: https://github.com/automationiberia/casc_setup/
 
 # The URL to the collection issue tracker
-issues: http://example.com/issue/tracker
+issues: https://github.com/automationiberia/casc_setup/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: automationiberia
 name: casc_setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.4
+version: 1.0.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/filetree_create/templates/README.md.j2
+++ b/roles/filetree_create/templates/README.md.j2
@@ -160,7 +160,7 @@ Before using CasC as a GitOps approach, it is needed to launch an initialization
 {% endraw %}
    ```
 
-   File: `orgs_vars/casc-twitch-demo/env/common/controller_job_templates.d/new_job_template.yaml`
+   File: `orgs_vars/{{ gitlab_project }}/env/common/controller_job_templates.d/new_job_template.yaml`
    ```yaml
 {%- raw %}
    ---

--- a/roles/filetree_create/templates/casc_ctrl_cd_webhook_trigger.yml.j2
+++ b/roles/filetree_create/templates/casc_ctrl_cd_webhook_trigger.yml.j2
@@ -1,6 +1,73 @@
 ---
 {%- raw %}
-- name: Include Gitlab Webhook Trigger Playbook from a collection AutomationIberia CasC_Setup
-  ansible.builtin.import_playbook: automationiberia.casc_setup.cd_gitlab_webhook_trigger.yml
+- hosts: all
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: "Get the modified files over the dirs from all the received commits"
+      set_fact:
+        __env: "{{ awx_webhook_payload.ref.split('/')[2] if awx_webhook_payload.ref.split('/')[1] == 'heads' else  awx_webhook_payload.project.default_branch }}"
+        __casc_gitlab_scm_branch: "{{ awx_webhook_payload.ref.split('/')[2] }}"
+        __list_of_dirs: "{{ ((awx_webhook_payload.commits | map(attribute='added') | list) +
+                           (awx_webhook_payload.commits | map(attribute='modified') | list) +
+                           (awx_webhook_payload.commits | map(attribute='removed') | list))
+                       | flatten }}"
+    # https://regex101.com/r/0SgpFn/1
+    - set_fact:
+        regexpression: "/([^/]*)/env/(common|{{ __env }})/controller_(.*).d/"
+
+    - name: "Get the Organization and the tags to run the CasC"
+      set_fact:
+        org_dirs_dict: "{{ (org_dirs_dict | default({})) | combine({input_var[0]: (((org_dirs_dict[input_var[0]] | default([])) + [input_var[1]] + ( ['projects','schedules'] if awx_webhook_payload.ref.split('/')[1] == 'tags' else [''] ) ) | unique | reject('match', '^$') ) }) }}"
+      vars:
+        input_var: "{{ input_var_item | regex_search(regexpression, '\\1', '\\3') }}"
+      loop: "{{ __list_of_dirs }}"
+      loop_control:
+        loop_var: input_var_item
+      when: input_var | type_debug is match('list')
+
+    - name: Configure Controller Job Launch | Launch launch_jobs Drop Diff (Delete)
+      include_role:
+        name: redhat_cop.controller_configuration.job_launch
+      vars:
+        controller_launch_jobs:
+          - name: "{{ __drop_diff_org_tags_item.key }} CasC_JobTemplates_AAP_Drop_Diff"
+            scm_branch: "{{ __casc_gitlab_scm_branch }}"
+            extra_vars:
+              orgs: "{{ __drop_diff_org_tags_item.key }}"
+              dir_orgs_vars: 'orgs_vars'
+              ansible_python_interpreter: "/usr/bin/python3"
+              env: "{{ __env }}"
+              casc_gitlab_scm_branch: "{{ __casc_gitlab_scm_branch }}"
+            tags: "{{ __drop_diff_org_tags_item.value }}"
+            wait: true
+            verbosity: 0
+      with_dict: "{{ org_dirs_dict }}"
+      loop_control:
+        loop_var: __drop_diff_org_tags_item
+      when: org_dirs_dict is defined
+
+    - name: Configure Controller Job Launch | Launch launch_jobs creation
+      include_role:
+        name: redhat_cop.controller_configuration.job_launch
+      vars:
+        controller_launch_jobs:
+          - name: "{{ __config_controller_org_tags_item.key }} CasC_JobTemplates_AAP_CD_Config_Controller"
+            scm_branch: "{{ __casc_gitlab_scm_branch }}"
+            extra_vars:
+              orgs: "{{ __config_controller_org_tags_item.key }}"
+              dir_orgs_vars: 'orgs_vars'
+              ansible_python_interpreter: "/usr/bin/python3"
+              env: "{{ __env }}"
+              casc_gitlab_scm_branch: "{{ __casc_gitlab_scm_branch }}"
+            tags: "{{ __config_controller_org_tags_item.value }}"
+            wait: true
+            verbosity: 0
+      with_dict: "{{ org_dirs_dict }}"
+      loop_control:
+        loop_var: __config_controller_org_tags_item
+      when: org_dirs_dict is defined
+
+# ansible-playbook ci-webhook-trigger.yml -e @orgs_vars/env/demo-dev/configure_connection_controller_credentials.yml --vault-password-file ./.vault_pass.txt -e @ci-webhook-variables.yml -e '{orgs: Global}'
 {% endraw %}
 ...

--- a/roles/filetree_create/templates/casc_ctrl_cd_webhook_trigger.yml.j2
+++ b/roles/filetree_create/templates/casc_ctrl_cd_webhook_trigger.yml.j2
@@ -31,7 +31,7 @@
         name: redhat_cop.controller_configuration.job_launch
       vars:
         controller_launch_jobs:
-          - name: "{{ __drop_diff_org_tags_item.key }} CasC_JobTemplates_AAP_Drop_Diff"
+          - name: "{{ __drop_diff_org_tags_item.key }} JT_CasC_Ctrl_Drop_Diff"
             scm_branch: "{{ __casc_gitlab_scm_branch }}"
             extra_vars:
               orgs: "{{ __drop_diff_org_tags_item.key }}"
@@ -52,7 +52,7 @@
         name: redhat_cop.controller_configuration.job_launch
       vars:
         controller_launch_jobs:
-          - name: "{{ __config_controller_org_tags_item.key }} CasC_JobTemplates_AAP_CD_Config_Controller"
+          - name: "{{ __config_controller_org_tags_item.key }} JT_CasC_Ctrl_Config"
             scm_branch: "{{ __casc_gitlab_scm_branch }}"
             extra_vars:
               orgs: "{{ __config_controller_org_tags_item.key }}"

--- a/roles/filetree_create/templates/casc_ctrl_config.yml.j2
+++ b/roles/filetree_create/templates/casc_ctrl_config.yml.j2
@@ -1,6 +1,69 @@
 ---
 {%- raw %}
-- name: Include  Config Controller Playbook from collection AutomationIberia CasC_Setup
-  ansible.builtin.import_playbook: automationiberia.casc_setup.config_controller.yml
+- hosts: all
+  connection: local
+  gather_facts: false
+  vars:
+    controller_configuration_projects_async_retries: 120
+    controller_configuration_projects_async_delay: 2
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_filetree_read_secure_logging | default('false') }}"
+      when: controller_oauthtoken is not defined
+      tags:
+        - always
+  roles:
+    - {role: redhat_cop.controller_configuration.filetree_read, assign_galaxy_credentials_to_org: false}
+    - {role: redhat_cop.controller_configuration.dispatch, assign_galaxy_credentials_to_org: false}
+
+  post_tasks:
+    - block:
+        - name: Include Tasks to load Galaxy credentials to be added to Organizations
+          ansible.builtin.include_role:
+            name: redhat_cop.controller_configuration.filetree_read
+            tasks_from: organizations.yml
+
+        - name: Include Tasks to add Galaxy credentials to Organizations
+          ansible.builtin.include_role:
+            name: redhat_cop.controller_configuration.dispatch
+            apply:
+              tags:
+                - organizations
+          vars:
+            controller_configuration_dispatcher_roles:
+              - {role: organizations, var: controller_organizations, tags: organizations}
+      tags:
+        - organizations
+
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 {% endraw %}
 ...

--- a/roles/filetree_create/templates/casc_ctrl_drop_diff.yml.j2
+++ b/roles/filetree_create/templates/casc_ctrl_drop_diff.yml.j2
@@ -1,6 +1,79 @@
 ---
 {%- raw %}
-- name: Include Drop Diff Playbook from collection AutomationIberia CasC_Setup
-  ansible.builtin.import_playbook: automationiberia.casc_setup.drop_diff.yml
+- hosts: all
+  connection: local
+  gather_facts: false
+  vars:
+    controller_configuration_projects_async_retries: 120
+    controller_configuration_projects_async_delay: 2
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_object_diff_secure_logging | default('false') }}"
+      when: controller_oauthtoken is not defined
+      tags:
+        - always
+  roles:
+    - role: redhat_cop.controller_configuration.filetree_read
+    - role: redhat_cop.controller_configuration.object_diff
+      vars:
+        controller_configuration_object_diff_tasks:
+          - {name: workflow_job_templates, var: controller_workflows, tags: workflow_job_templates}
+          - {name: job_templates, var: controller_templates, tags: job_templates}
+          # - {name: teams, var: controller_teams, tags: teams#}
+          # - {name: user_accounts, var: controller_user_accounts, tags: users}
+          - {name: groups, var: controller_groups, tags: groups}
+          - {name: hosts, var: controller_hosts, tags: hosts}
+          - {name: inventory_sources, var: controller_inventory_sources, tags: inventory_sources}
+          - {name: inventories, var: controller_inventories, tags: inventories}
+          - {name: projects, var: controller_projects, tags: projects}
+          - {name: credentials, var: controller_credentials, tags: credentials}
+          # - {name: credential_types, var: controller_credential_types, tags: credential_types}
+          - {name: organizations, var: controller_organizations, tags: organizations}
+    - role: redhat_cop.controller_configuration.dispatch
+      vars:
+        controller_configuration_dispatcher_roles:
+          - {role: workflow_job_templates, var: controller_workflows, tags: workflow_job_templates}
+          - {role: job_templates, var: controller_templates, tags: job_templates}
+          # - {role: teams, var: controller_teams, tags: teams}
+          # - {role: users, var: controller_user_accounts, tags: users}
+          - {role: groups, var: controller_groups, tags: inventories}
+          - {role: hosts, var: controller_hosts, tags: hosts}
+          - {role: projects, var: controller_projects, tags: projects}
+          - {role: inventory_sources, var: controller_inventory_sources, tags: inventory_sources}
+          - {role: inventories, var: controller_inventories, tags: inventories}
+          - {role: credentials, var: controller_credentials, tags: credentials}
+          # - {role: credential_types, var: controller_credential_types, tags: credential_types}
+          - {role: organizations, var: controller_organizations, tags: organizations}
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 {% endraw %}
 ...

--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -31,8 +31,8 @@ controller_credentials:
 {%- raw %}
       token: "Hub - Token"
 
-  - name: "{{ orgs }} {{ env }} AAP Credentials"
-    description: "{ orgs }} {{ env }} Ansible Automation Platform Credentials"
+  - name: "{{ orgs }} {{ env }} AAP Credential"
+    description: "{ orgs }} {{ env }} Ansible Automation Platform Credential"
     credential_type: "Red Hat Ansible Automation Platform"
     organization: "{{ orgs }}"
     inputs:
@@ -41,8 +41,8 @@ controller_credentials:
       password: "{{ controller_password }}"
       verify_ssl: "{{ controller_validate_certs }}"
 
-  - name: "{{ orgs }} {{ env }} Vault Credentials"
-    description: "{{ orgs }} {{ env }} Vault Credentials"
+  - name: "{{ orgs }} {{ env }} Vault Credential"
+    description: "{{ orgs }} {{ env }} Vault Credential"
     credential_type: "Vault"
     organization: "{{ orgs }}"
     inputs:

--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -5,7 +5,7 @@ controller_templates:
     description: "Template to attend Controller CasC webhook"
     organization: "{{ orgs }}"
     project: "{{ orgs }} CasC_Data"
-    inventory: "{{ orgs }} Controller"
+    inventory: "superadmin Controller"
     playbook: "casc_ctrl_cd_webhook_trigger.yml"
     job_type: run
     fact_caching_enabled: false
@@ -22,7 +22,7 @@ controller_templates:
     description: "Template to deploy Controller objects in Org {{ orgs }}"
     organization: "{{ orgs }}"
     project: "{{ orgs }} CasC_Data"
-    inventory: "{{ orgs }} Controller"
+    inventory: "superadmin Controller"
     playbook: "casc_config_ctrl.yml"
     job_type: run
     fact_caching_enabled: false
@@ -43,7 +43,7 @@ controller_templates:
     description: "Template to assure no difference between API and repository"
     organization: "{{ orgs }}"
     project: "{{ orgs }} CasC_Data"
-    inventory: "{{ orgs }} Controller"
+    inventory: "superadmin Controller"
     playbook: "casc_ctrl_drop_diff.yml"
     job_type: run
     fact_caching_enabled: false


### PR DESCRIPTION
- Rollback templates to use playbooks logic within each org. When importing playboks from collection, the playbook_dir will be within the collection, so the path will be where the collections is, so the org_vars won't be loaded because it won't be found. I've found a workaround to run it from the terminal, but it doesn't work in AWX/Controller because is other path. We need to think a better solution to be able to distribute the logic through the collection.

```
---
- hosts: all
  connection: local
  gather_facts: false
  tasks:
    - set_fact:
        search_path: "{{ playbook_dir }}"
      tags:
        - always

- name: Include  Config Controller Playbook from collection AutomationIberia CasC_Setup
  ansible.builtin.import_playbook: automationiberia.casc_setup.config_controller.yml
  vars:
    filetree_controller_settings: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_settings.d/"
    filetree_controller_organizations: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_organizations.d/"
    filetree_controller_labels: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_labels.d/"
    filetree_controller_user_accounts: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_users.d/"
    filetree_controller_teams: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_teams.d/"
    filetree_controller_credential_types: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_credential_types.d/"
    filetree_controller_credentials: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_credentials.d/"
    filetree_controller_credential_input_sources: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_credential_input_sources.d/"
    filetree_controller_notifications: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_notification_templates.d/"
    filetree_controller_projects: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_projects.d/"
    filetree_controller_execution_environments: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_execution_environments.d/"
    filetree_controller_applications: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_applications.d/"
    filetree_controller_inventories: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_inventories.d/"
    filetree_controller_inventory_sources: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_inventory_sources.d/"
    filetree_controller_instance_groups: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_instance_groups.d/"
    filetree_controller_hosts: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_hosts.d/"
    filetree_controller_groups: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_groups.d/"
    filetree_controller_templates: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_job_templates.d/"
    filetree_controller_workflow_job_templates: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_workflow_job_templates.d/"
    filetree_controller_schedules: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_schedules.d/"
    filetree_controller_roles: "{{ search_path }}/{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_roles.d/"

```