### PR TITLE
Fix typo credential AAP

### DIFF
--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -32,7 +32,7 @@ controller_credentials:
       token: "Hub - Token"
 
   - name: "{{ orgs }} {{ env }} AAP Credential"
-    description: "{ orgs }} {{ env }} Ansible Automation Platform Credential"
+    description: "{{ orgs }} {{ env }} Ansible Automation Platform Credential"
     credential_type: "Red Hat Ansible Automation Platform"
     organization: "{{ orgs }}"
     inputs:


### PR DESCRIPTION
- Fix description of the AAP credential it was missing one"{" -> "{{ orgs }} {{ env }} Ansible Automation Platform Credential"